### PR TITLE
Update LSP servers and formatters for work config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,2 +1,3 @@
 -- bootstrap lazy.nvim, LazyVim and your plugins
 require("config.lazy")
+vim.o.termguicolors = true

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -4,9 +4,6 @@ return {
     opts.formatters_by_ft = vim.tbl_extend("force", opts.formatters_by_ft or {}, {
       nix = { "alejandra" },
       lua = { "stylua" },
-      sh = { "shfmt" },
-      bash = { "shfmt" },
-      zsh = { "shfmt" },
       python = { "ruff" },
       javascript = { "prettierd", "prettier" },
       typescript = { "prettierd", "prettier" },

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -24,9 +24,7 @@ return {
         },
       },
 
-      pyright = { mason = false },
-      bashls = { mason = false },
-      rust_analyzer = { mason = false },
+      ruff = { mason = false },
       tsserver = { mason = false }, -- or switch to vtsls if you prefer
     },
   },

--- a/lua/plugins/markdown-preview.lua
+++ b/lua/plugins/markdown-preview.lua
@@ -1,0 +1,9 @@
+return {
+  "iamcco/markdown-preview.nvim",
+  cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+  build = ":call mkdp#util#install()",
+  init = function()
+    vim.g.mkdp_filetypes = { "markdown" }
+  end,
+  ft = { "markdown" },
+}


### PR DESCRIPTION
This PR aligns the nvim configuration with the packages installed via home-manager in the WSL environment.

## Changes:
- ✅ Add `vim.o.termguicolors = true` in init.lua for true color support
- ✅ Add markdown-preview plugin for markdown editing
- ✅ Replace `pyright` with `ruff` for Python LSP (matches home.nix)
- ❌ Remove `bashls` LSP (not needed for WSL setup)
- ❌ Remove `rust_analyzer` LSP (not needed for WSL setup)
- ❌ Remove `shfmt` formatters for sh/bash/zsh (not in Nix config)

This ensures the nvim config only references tools that are actually installed via the nix-home flake.